### PR TITLE
Fix telegraf_pfifgw.php "Monitor IP"

### DIFF
--- a/plugins/telegraf_pfifgw.php
+++ b/plugins/telegraf_pfifgw.php
@@ -350,7 +350,7 @@ foreach ($gw_array as $gw => $gateway) {
     if (!isset($gwdescr)) {
         $gwdescr = "Unassigned";
     }
-    if (isset($gateway['monitor_disable'])) {
+    if (!isset($gateway['monitor_disable'])) {
         $monitor = "Unmonitored";
     }
 


### PR DESCRIPTION
Missing "!" in code, which prevented retrieval of "Monitor IP", resulting in "Unmonitored" despite correct configuration in OPNsense.